### PR TITLE
Add Contributor Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in this project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language  
+- Being respectful of differing viewpoints and experiences  
+- Gracefully accepting constructive criticism  
+- Focusing on what is best for the community  
+- Showing empathy towards other community members  
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances  
+- Trolling, insulting/derogatory comments, and personal or political attacks  
+- Public or private harassment  
+- Publishing others' private information, such as a physical or electronic address, without explicit permission  
+- Other conduct which could reasonably be considered inappropriate in a professional setting  
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Reporting Guidelines
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [YOUR EMAIL ADDRESS]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Enforcement
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to temporarily or permanently ban any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), available under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
This PR adds a `CODE_OF_CONDUCT.md` file to the repository based on the standard Contributor Covenant v2.1. 

It defines expected community behavior, reporting mechanisms, and enforcement policies to create a safe, welcoming, and inclusive environment for all contributors.

This PR closes #32.
